### PR TITLE
Update to Python 3.9.6

### DIFF
--- a/Android/build_deps.py
+++ b/Android/build_deps.py
@@ -63,7 +63,7 @@ class BZip2(Package):
         self.run(['install', '-Dm644', 'bzlib.h', '-t', str(SYSROOT / 'usr' / 'include')])
 
 class GDBM(Package):
-    source = 'https://ftp.gnu.org/gnu/gdbm/gdbm-1.18.1.tar.gz'
+    source = 'https://ftp.gnu.org/gnu/gdbm/gdbm-1.20.tar.gz'
     configure_args = ['--enable-libgdbm-compat']
 
 class LibFFI(Package):
@@ -72,7 +72,7 @@ class LibFFI(Package):
     configure_args = ['--disable-builddir']
 
 class LibUUID(Package):
-    source = 'https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.36/util-linux-2.36.tar.xz'
+    source = 'https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.37/util-linux-2.37.tar.xz'
     configure_args = ['--disable-all-programs', '--enable-libuuid']
 
 class NCurses(Package):
@@ -81,7 +81,7 @@ class NCurses(Package):
     configure_args = ['--without-ada', '--enable-widec', '--without-debug', '--without-cxx-binding', '--disable-stripping']
 
 class OpenSSL(Package):
-    source = 'https://www.openssl.org/source/openssl-1.1.1h.tar.gz'
+    source = 'https://www.openssl.org/source/openssl-3.0.0-beta1.tar.gz'
 
     def configure(self):
         # OpenSSL handles NDK internal paths by itself
@@ -106,7 +106,7 @@ class OpenSSL(Package):
         self.run(['make', 'install_sw', 'install_ssldirs', f'DESTDIR={SYSROOT}'])
 
 class Readline(Package):
-    source = 'https://ftp.gnu.org/gnu/readline/readline-8.0.tar.gz'
+    source = 'https://ftp.gnu.org/gnu/readline/readline-8.1.tar.gz'
 
     # See the wcwidth() test in aclocal.m4. Tested on Android 6.0 and it's broken
     # XXX: wcwidth() is implemented in [1], which may be in Android P
@@ -115,7 +115,7 @@ class Readline(Package):
     configure_args = ['bash_cv_wcwidth_broken=yes']
 
 class SQLite(Package):
-    source = 'https://sqlite.org/2020/sqlite-autoconf-3330000.tar.gz'
+    source = 'https://sqlite.org/2021/sqlite-autoconf-3350500.tar.gz'
 
 class XZ(Package):
     source = 'https://tukaani.org/xz/xz-5.2.5.tar.xz'

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 Python 3 Android
 ================
 
-This is an experimental set of build scripts that will cross-compile Python 3.9.5 for an Android device.
+This is an experimental set of build scripts that will cross-compile Python 3.9.6 for an Android device.
 
 Building requires:
 
 1. Linux. This project might work on other systems supported by NDK but no guarantee.
 2. Android NDK r21 installed and environment variable ``$ANDROID_NDK`` points to its root directory. Older NDK may not work and NDK <= r18 is known to be incompatible.
-3. `python3.9` binary from Python 3.9.5 on the building host. It's recommended to use exactly that Python version, which can be installed via [pyenv](https://github.com/yyuu/pyenv). Don't forget to check that `python3.9` is available in $PATH.
+3. `python3.9` binary from Python 3.9.6 on the building host. It's recommended to use exactly that Python version, which can be installed via [pyenv](https://github.com/yyuu/pyenv). Don't forget to check that `python3.9` is available in $PATH.
 4. `tic` binary from ncurses 6.2 on the building host. Slightly newer or older version may also work but no guarantee.
 5. A case-sensitive filesystem. The default filesystem on Windows and macOS is case-insensitive, and building may fail.
 
@@ -23,8 +23,8 @@ Build
 2. For every API Level/architecture combination you wish to build for:
    * `ARCH=arm ANDROID_API=21 ./build.sh` to build everything!
 3. Here are a couple of examples to build a static version of the library with docker.
-   * Build 64 bit `sudo docker run --rm -it -v $(pwd):/python3-android -v ${NDK_PATH}:/android-ndk:ro --env ARCH=arm64 --env ANDROID_API=23 python:3.9.5-slim /python3-android/docker-build.sh --enable-shared --without-ensurepip --disable-ipv6`
-   * Build 32 bit `sudo docker run --rm -it -v $(pwd):/python3-android -v ${NDK_PATH}:/android-ndk:ro --env ARCH=arm --env ANDROID_API=23 python:3.9.5-slim /python3-android/docker-build.sh --enable-shared --without-ensurepip --disable-ipv6`
+   * Build 64 bit `sudo docker run --rm -it -v $(pwd):/python3-android -v ${NDK_PATH}:/android-ndk:ro --env ARCH=arm64 --env ANDROID_API=23 python:3.9.6-slim /python3-android/docker-build.sh --enable-shared --without-ensurepip --disable-ipv6`
+   * Build 32 bit `sudo docker run --rm -it -v $(pwd):/python3-android -v ${NDK_PATH}:/android-ndk:ro --env ARCH=arm --env ANDROID_API=23 python:3.9.6-slim /python3-android/docker-build.sh --enable-shared --without-ensurepip --disable-ipv6`
 
 Build using Docker/Podman
 ------------------
@@ -32,7 +32,7 @@ Build using Docker/Podman
 Download the latest NDK for Linux from https://developer.android.com/ndk/downloads and extract it.
 
 ```
-docker run --rm -it -v $(pwd):/python3-android -v /path/to/android-ndk:/android-ndk:ro --env ARCH=arm --env ANDROID_API=21 python:3.9.5-slim /python3-android/docker-build.sh
+docker run --rm -it -v $(pwd):/python3-android -v /path/to/android-ndk:/android-ndk:ro --env ARCH=arm --env ANDROID_API=21 python:3.9.6-slim /python3-android/docker-build.sh
 ```
 
 Here `/path/to/android-ndk` should be replaced with the actual for NDK (e.g., `/opt/android-ndk`).

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -x
 
 THIS_DIR="$PWD"
 
-PYVER=3.9.5
+PYVER=3.9.6
 SRCDIR=src/Python-$PYVER
 
 COMMON_ARGS="--arch ${ARCH:-arm} --api ${ANDROID_API:-21}"

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -11,7 +11,7 @@ export ANDROID_NDK=/android-ndk
 if [ ! -d "$ANDROID_NDK" ] ; then
     # In general we don't want download NDK for every build, but it is simpler to do it here
     # for CI builds
-    NDK_VER=r21e
+    NDK_VER=r22b
     apt-get install -y wget bsdtar
     wget --no-verbose https://dl.google.com/android/repository/android-ndk-$NDK_VER-linux-x86_64.zip
     bsdtar xf android-ndk-${NDK_VER}-linux-x86_64.zip


### PR DESCRIPTION
This is the update to Python 3.9.6.  I took Yan's NDK 23 updates as well so that I could move to the latest stable NDK of 22b.