### PR TITLE
3.10.4

### DIFF
--- a/Android/build_deps.py
+++ b/Android/build_deps.py
@@ -121,7 +121,7 @@ class XZ(Package):
     source = 'https://tukaani.org/xz/xz-5.2.5.tar.xz'
 
 class ZLib(Package):
-    source = 'https://www.zlib.net/zlib-1.2.11.tar.gz'
+    source = 'https://www.zlib.net/zlib-1.2.12.tar.gz'
 
     def configure(self):
         os.environ.update({

--- a/Android/build_deps.py
+++ b/Android/build_deps.py
@@ -63,25 +63,25 @@ class BZip2(Package):
         self.run(['install', '-Dm644', 'bzlib.h', '-t', str(SYSROOT / 'usr' / 'include')])
 
 class GDBM(Package):
-    source = 'https://ftp.gnu.org/gnu/gdbm/gdbm-1.20.tar.gz'
+    source = 'https://ftp.gnu.org/gnu/gdbm/gdbm-1.23.tar.gz'
     configure_args = ['--enable-libgdbm-compat']
 
 class LibFFI(Package):
-    source = 'https://github.com/libffi/libffi/releases/download/v3.3/libffi-3.3.tar.gz'
+    source = 'https://github.com/libffi/libffi/releases/download/v3.4.2/libffi-3.4.2.tar.gz'
     # libffi may fail to configure with Docker on WSL2 (#33)
     configure_args = ['--disable-builddir']
 
 class LibUUID(Package):
-    source = 'https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.37/util-linux-2.37.tar.xz'
+    source = 'https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.38/util-linux-2.38.tar.xz'
     configure_args = ['--disable-all-programs', '--enable-libuuid']
 
 class NCurses(Package):
-    source = 'https://invisible-mirror.net/archives/ncurses/ncurses-6.2.tar.gz'
+    source = 'https://invisible-mirror.net/archives/ncurses/ncurses-6.3.tar.gz'
     # Not stripping the binaries as there is no easy way to specify the strip program for Android
     configure_args = ['--without-ada', '--enable-widec', '--without-debug', '--without-cxx-binding', '--disable-stripping']
 
 class OpenSSL(Package):
-    source = 'https://www.openssl.org/source/openssl-3.0.0.tar.gz'
+    source = 'https://www.openssl.org/source/openssl-3.0.2.tar.gz'
 
     def configure(self):
         # OpenSSL handles NDK internal paths by itself
@@ -106,7 +106,7 @@ class OpenSSL(Package):
         self.run(['make', 'install_sw', 'install_ssldirs', f'DESTDIR={SYSROOT}'])
 
 class Readline(Package):
-    source = 'https://ftp.gnu.org/gnu/readline/readline-8.1.tar.gz'
+    source = 'https://ftp.gnu.org/gnu/readline/readline-8.1.2.tar.gz'
 
     # See the wcwidth() test in aclocal.m4. Tested on Android 6.0 and it's broken
     # XXX: wcwidth() is implemented in [1], which may be in Android P
@@ -115,7 +115,7 @@ class Readline(Package):
     configure_args = ['bash_cv_wcwidth_broken=yes']
 
 class SQLite(Package):
-    source = 'https://sqlite.org/2021/sqlite-autoconf-3350500.tar.gz'
+    source = 'https://sqlite.org/2022/sqlite-autoconf-3380200.tar.gz'
 
 class XZ(Package):
     source = 'https://tukaani.org/xz/xz-5.2.5.tar.xz'

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Build
    <br>Here are a couple of examples to build a static version of the library with docker.
    * Build 64 bit `sudo docker run --rm -it -v $(pwd):/python3-android -v ${NDK_PATH}:/android-ndk:ro --env ARCH=arm64 --env ANDROID_API=23 python:3.10.4-slim /python3-android/docker-build.sh --enable-shared --without-ensurepip --disable-ipv6`
    * Build 32 bit `sudo docker run --rm -it -v $(pwd):/python3-android -v ${NDK_PATH}:/android-ndk:ro --env ARCH=arm --env ANDROID_API=23 python:3.10.4-slim /python3-android/docker-build.sh --enable-shared --without-ensurepip --disable-ipv6`
+   * Build x86_64 `sudo docker run --rm -it -v $(pwd):/python3-android -v ${NDK_PATH}:/android-ndk:ro --env ARCH=x86_64 --env ANDROID_API=23 python:3.10.4-slim /python3-android/docker-build.sh --enable-shared --without-ensurepip --disable-ipv6`
 
 
 Installation & Running
@@ -57,7 +58,6 @@ Check SSL/TLS functionality with:
 import urllib.request
 print(urllib.request.urlopen('https://httpbin.org/ip').read().decode('ascii'))
 ```
-
 
 Known Issues
 ------------

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Python 3 Android
 ================
 
-This is an experimental set of build scripts that will cross-compile Python 3.10.0 for an Android device.
+This is an experimental set of build scripts that will cross-compile Python 3.10.4 for an Android device.
 
 Building requires:
 -----
@@ -15,7 +15,7 @@ Running requires:
 -----
 
 1. Android 5.0 (Lollipop, API 21) or above
-2. arm, arm64
+2. arm, arm64, x86, x86_64
 
 <br>
 Build
@@ -24,8 +24,8 @@ Build
 1. Run `sudo ./clean.sh` for good measure, and after each build.
 2. You will need a seperate build run for every API Level/architecture combination you wish to run on:
    <br>Here are a couple of examples to build a static version of the library with docker.
-   * Build 64 bit `sudo docker run --rm -it -v $(pwd):/python3-android -v ${NDK_PATH}:/android-ndk:ro --env ARCH=arm64 --env ANDROID_API=23 python:3.10.0-slim /python3-android/docker-build.sh --enable-shared --without-ensurepip --disable-ipv6`
-   * Build 32 bit `sudo docker run --rm -it -v $(pwd):/python3-android -v ${NDK_PATH}:/android-ndk:ro --env ARCH=arm --env ANDROID_API=23 python:3.10.0-slim /python3-android/docker-build.sh --enable-shared --without-ensurepip --disable-ipv6`
+   * Build 64 bit `sudo docker run --rm -it -v $(pwd):/python3-android -v ${NDK_PATH}:/android-ndk:ro --env ARCH=arm64 --env ANDROID_API=23 python:3.10.4-slim /python3-android/docker-build.sh --enable-shared --without-ensurepip --disable-ipv6`
+   * Build 32 bit `sudo docker run --rm -it -v $(pwd):/python3-android -v ${NDK_PATH}:/android-ndk:ro --env ARCH=arm --env ANDROID_API=23 python:3.10.4-slim /python3-android/docker-build.sh --enable-shared --without-ensurepip --disable-ipv6`
 
 
 Installation & Running

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -x
 
 THIS_DIR="$PWD"
 
-PYVER=3.10.0
+PYVER=3.10.4
 SRCDIR=src/Python-$PYVER
 
 COMMON_ARGS="--arch ${ARCH:-arm} --api ${ANDROID_API:-23}"


### PR DESCRIPTION
This updated the Python build to be 3.10.4, as well as updates all of the build dependencies.  This also starts the use of x86_64, before I only used arm and arm64